### PR TITLE
Automate post-merge PT-BR translation PRs

### DIFF
--- a/.github/workflows/translate-post.yml
+++ b/.github/workflows/translate-post.yml
@@ -1,0 +1,143 @@
+name: Create translation PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      notebook:
+        description: English source notebook under posts/
+        required: true
+        default: posts/2026-07-23-Scaling-MyPost-WithAIAgents.ipynb
+        type: string
+  push:
+    branches:
+      - main
+    paths:
+      - "posts/*.ipynb"
+
+concurrency:
+  group: translation-${{ github.event.inputs.notebook || github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  select:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.sources.outputs.matrix }}
+      has-sources: ${{ steps.sources.outputs.has-sources }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: sources
+        env:
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
+          MANUAL_SOURCE: ${{ github.event.inputs.notebook }}
+        run: |
+          if [[ -n "$MANUAL_SOURCE" ]]; then
+            matrix="$(python experiments/scaling-my-posts/src/translation_workflow.py \
+              --manual-source "$MANUAL_SOURCE")"
+          else
+            matrix="$(python experiments/scaling-my-posts/src/translation_workflow.py \
+              --before "$BEFORE" --after "$AFTER")"
+          fi
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          if [[ "$matrix" == '{"source":[]}' ]]; then
+            echo "has-sources=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-sources=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  translate:
+    needs: select
+    if: needs.select.outputs.has-sources == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    permissions:
+      contents: write
+      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.select.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache the pinned Tower+ model
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: tower-plus-2b-4d779ca939174189c0677d4a75642d36d6a33b66
+
+      - name: Build the runner-compatible image
+        run: >-
+          docker compose
+          -f experiments/scaling-my-posts/docker/docker-compose.ci.yml
+          build translation-ci
+
+      - name: Generate and pair the PT-BR notebook
+        env:
+          SOURCE: ${{ matrix.source }}
+        run: |
+          target="${SOURCE%.ipynb}-pt-BR.ipynb"
+          docker compose \
+            -f experiments/scaling-my-posts/docker/docker-compose.ci.yml \
+            run --rm \
+            -v "$HOME/.cache/huggingface:/model-cache" \
+            --entrypoint python translation-ci \
+            experiments/scaling-my-posts/src/translate_notebook.py \
+            "$SOURCE" "$target" --pair-source
+          echo "TARGET=$target" >> "$GITHUB_ENV"
+
+      - name: Run deployment-focused tests
+        run: >-
+          docker compose
+          -f experiments/scaling-my-posts/docker/docker-compose.ci.yml
+          run --rm translation-ci --notebook "${{ matrix.source }}" --skip-render
+
+      - name: Render both language versions
+        env:
+          SOURCE: ${{ matrix.source }}
+        run: |
+          docker compose \
+            -f experiments/scaling-my-posts/docker/docker-compose.ci.yml \
+            run --rm --entrypoint quarto translation-ci \
+            render "$SOURCE" --to html -M draft:false
+          docker compose \
+            -f experiments/scaling-my-posts/docker/docker-compose.ci.yml \
+            run --rm --entrypoint quarto translation-ci \
+            render "$TARGET" --to html -M draft:false
+
+      - name: Upload the rendered review artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: translation-preview-${{ strategy.job-index }}
+          path: _site
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Open a separate translation PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE: ${{ matrix.source }}
+        run: |
+          stem="$(basename "${SOURCE%.ipynb}")"
+          branch="translation/${stem}-${GITHUB_SHA:0:8}"
+          git switch -c "$branch"
+          git add "$SOURCE" "$TARGET"
+          if git diff --cached --quiet; then
+            echo "No translation changes were produced."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "Add PT-BR translation for ${stem}"
+          git push origin "$branch"
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --draft \
+            --title "Add PT-BR translation for ${stem}" \
+            --body-file experiments/scaling-my-posts/templates/translation-pr.md

--- a/README.md
+++ b/README.md
@@ -65,8 +65,14 @@ article. Quarto converts each notebook to HTML as part of the preview.
 
 The intended automation runs only after the source-content PR has been reviewed
 and merged. The resulting push to `main` triggers translation, validation, and a
-temporary preview, then opens a separate translation PR. Human review and merging
-of that translation PR remain distinct from the original source review.
+temporary rendered artifact, then opens a separate translation PR. Human review
+and merging of that translation PR remain distinct from the original source
+review.
+
+The workflow can also be started manually from **Actions → Create translation
+PR → Run workflow**. Supply the English notebook path under `posts/`; this is
+useful for a source post that reached `main` before the workflow was installed.
+The generated pull request is a draft and includes the publication checklist.
 
 ## Reproducing the translation evaluation
 

--- a/experiments/scaling-my-posts/src/translate_notebook.py
+++ b/experiments/scaling-my-posts/src/translate_notebook.py
@@ -256,6 +256,46 @@ def portuguese_frontmatter(source: str, english_name: str) -> str:
     return "\n".join(result)
 
 
+def source_frontmatter(source: str, translation_name: str) -> str:
+    """Add or update the reciprocal translation link in source front matter."""
+    lines = source.splitlines()
+    result: list[str] = []
+    inserted_pairing = False
+    found_lang = False
+    for line in lines:
+        key = line.split(":", 1)[0].strip() if ":" in line else ""
+        if key == "language-version":
+            continue
+        if key == "translation":
+            if not inserted_pairing:
+                result.append(f"translation: {translation_name}")
+                inserted_pairing = True
+            continue
+        result.append(line)
+        if key == "lang":
+            found_lang = True
+            if not inserted_pairing:
+                result.append(f"translation: {translation_name}")
+                inserted_pairing = True
+    if not found_lang:
+        raise ValueError("Notebook front matter must contain a lang field")
+    return "\n".join(result)
+
+
+def pair_source_notebook(source: Path, translation_name: str) -> None:
+    """Persist the English side of a reciprocal notebook translation pair."""
+    notebook = json.loads(source.read_text(encoding="utf-8"))
+    first_cell = notebook["cells"][0]
+    raw = "".join(first_cell["source"])
+    first_cell["source"] = source_frontmatter(
+        raw, translation_name
+    ).splitlines(keepends=True)
+    source.write_text(
+        json.dumps(notebook, ensure_ascii=False, indent=1) + "\n",
+        encoding="utf-8",
+    )
+
+
 class TowerMarkdownTranslator:
     def __init__(self) -> None:
         import torch
@@ -342,7 +382,12 @@ class TowerMarkdownTranslator:
         ]
 
 
-def translate_notebook(source: Path, output: Path) -> None:
+def translate_notebook(
+    source: Path,
+    output: Path,
+    *,
+    pair_source: bool = False,
+) -> None:
     source_text = source.read_text(encoding="utf-8")
     source_notebook = json.loads(source_text)
     notebook = json.loads(source_text)
@@ -455,6 +500,8 @@ def translate_notebook(source: Path, output: Path) -> None:
         json.dumps(notebook, ensure_ascii=False, indent=1) + "\n",
         encoding="utf-8",
     )
+    if pair_source:
+        pair_source_notebook(source, output.name)
     progress_path.unlink(missing_ok=True)
 
 
@@ -462,9 +509,14 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("source", type=Path)
     parser.add_argument("output", type=Path)
+    parser.add_argument(
+        "--pair-source",
+        action="store_true",
+        help="Add the reciprocal translation metadata to the source notebook.",
+    )
     return parser.parse_args()
 
 
 if __name__ == "__main__":
     args = parse_args()
-    translate_notebook(args.source, args.output)
+    translate_notebook(args.source, args.output, pair_source=args.pair_source)

--- a/experiments/scaling-my-posts/src/translation_workflow.py
+++ b/experiments/scaling-my-posts/src/translation_workflow.py
@@ -1,0 +1,91 @@
+"""Select source notebooks for the post-merge translation workflow."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+
+def frontmatter_value(notebook_path: Path, key: str) -> str | None:
+    notebook = json.loads(notebook_path.read_text(encoding="utf-8"))
+    if not notebook["cells"]:
+        return None
+    source = "".join(notebook["cells"][0].get("source", []))
+    prefix = f"{key}:"
+    for line in source.splitlines():
+        if line.strip().startswith(prefix):
+            return line.split(":", 1)[1].strip().strip("'\"")
+    return None
+
+
+def select_sources(
+    changed_paths: list[str],
+    *,
+    repository: Path,
+    manual_source: str | None = None,
+) -> list[str]:
+    """Return English sources, excluding the reciprocal translation-merge loop."""
+    normalized_changes = {Path(path).as_posix() for path in changed_paths}
+    candidates = [manual_source] if manual_source else sorted(normalized_changes)
+    selected: list[str] = []
+    for candidate in candidates:
+        if not candidate:
+            continue
+        relative = Path(candidate).as_posix()
+        path = repository / relative
+        if (
+            not relative.startswith("posts/")
+            or path.suffix != ".ipynb"
+            or not path.exists()
+            or frontmatter_value(path, "language-version") == "translation"
+        ):
+            continue
+        translation = frontmatter_value(path, "translation")
+        if (
+            not manual_source
+            and translation
+            and (path.parent / translation).relative_to(repository).as_posix()
+            in normalized_changes
+        ):
+            continue
+        selected.append(relative)
+    return selected
+
+
+def changed_notebooks(before: str, after: str, repository: Path) -> list[str]:
+    if not before or set(before) == {"0"}:
+        before = f"{after}^"
+    result = subprocess.run(
+        ["git", "diff", "--name-only", before, after, "--", "posts/*.ipynb"],
+        cwd=repository,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return result.stdout.splitlines()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", type=Path, default=Path.cwd())
+    parser.add_argument("--before")
+    parser.add_argument("--after")
+    parser.add_argument("--manual-source")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    changes = (
+        []
+        if args.manual_source
+        else changed_notebooks(args.before, args.after, args.repository)
+    )
+    sources = select_sources(
+        changes,
+        repository=args.repository,
+        manual_source=args.manual_source,
+    )
+    print(json.dumps({"source": sources}, separators=(",", ":")))

--- a/experiments/scaling-my-posts/templates/translation-pr.md
+++ b/experiments/scaling-my-posts/templates/translation-pr.md
@@ -1,0 +1,13 @@
+This draft PR was created after the English source post was merged.
+
+The Portuguese notebook was generated with the pinned Tower+ 2B revision and
+remains a Quarto draft until a human reviewer approves its language and meaning.
+The creating Actions run retains a rendered site artifact for 14 days.
+
+Review checklist:
+
+- [ ] Compare the PT-BR text with the English source.
+- [ ] Check technical terminology, links, code, images, and headings.
+- [ ] Resolve the machine-translation warning.
+- [ ] Change `draft: true` to `draft: false` when the translation is publishable.
+- [ ] Preview both pages and test the PT-BR/EN language switch.

--- a/experiments/scaling-my-posts/tests/test_translate_notebook.py
+++ b/experiments/scaling-my-posts/tests/test_translate_notebook.py
@@ -16,6 +16,7 @@ from translate_notebook import (  # noqa: E402
     is_structural_block,
     materialize_translation,
     protect,
+    source_frontmatter,
     split_markdown,
     translate_around_protected,
     validate_heading_parity,
@@ -39,6 +40,29 @@ def test_materialize_accepts_an_already_reconstructed_fallback() -> None:
     protected = {"ZXQPROTECTED0000QXZ": "[the article](https://example.com)"}
     translated = "Leia [o artigo](https://example.com)."
     assert materialize_translation(translated, protected) == translated
+
+
+def test_source_frontmatter_adds_an_idempotent_reciprocal_pair() -> None:
+    source = "---\ntitle: Example\nlang: en\n---"
+    paired = source_frontmatter(source, "example-pt-BR.ipynb")
+    assert paired.count("translation: example-pt-BR.ipynb") == 1
+    assert "language-version:" not in paired
+    assert source_frontmatter(paired, "example-pt-BR.ipynb") == paired
+
+
+def test_published_notebook_image_paths_are_portable() -> None:
+    posts = ROOT / "posts"
+    for notebook_path in posts.glob("*.ipynb"):
+        notebook = json.loads(notebook_path.read_text(encoding="utf-8"))
+        markdown = "".join(
+            "".join(cell.get("source", []))
+            for cell in notebook["cells"]
+            if cell["cell_type"] == "markdown"
+        )
+        assert "](" not in markdown or not any(
+            "\\" in destination.split(")", 1)[0]
+            for destination in markdown.split("](")[1:]
+        ), f"{notebook_path.name} contains a Windows-style Markdown link"
 
 
 def test_folded_notebook_code_matches_the_experiment_sources() -> None:

--- a/experiments/scaling-my-posts/tests/test_translation_workflow.py
+++ b/experiments/scaling-my-posts/tests/test_translation_workflow.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SRC = ROOT / "experiments" / "scaling-my-posts" / "src"
+sys.path.insert(0, str(SRC))
+
+from translation_workflow import select_sources  # noqa: E402
+
+
+def write_notebook(path: Path, frontmatter: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "cells": [
+                    {
+                        "cell_type": "raw",
+                        "metadata": {},
+                        "source": frontmatter.splitlines(keepends=True),
+                    }
+                ],
+                "metadata": {},
+                "nbformat": 4,
+                "nbformat_minor": 5,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_an_english_only_change_starts_translation(tmp_path: Path) -> None:
+    source = "posts/example.ipynb"
+    write_notebook(
+        tmp_path / source,
+        "---\nlang: en\ntranslation: example-pt-BR.ipynb\n---\n",
+    )
+    assert select_sources([source], repository=tmp_path) == [source]
+
+
+def test_a_reciprocal_pair_change_does_not_loop(tmp_path: Path) -> None:
+    source = "posts/example.ipynb"
+    translation = "posts/example-pt-BR.ipynb"
+    write_notebook(
+        tmp_path / source,
+        "---\nlang: en\ntranslation: example-pt-BR.ipynb\n---\n",
+    )
+    write_notebook(
+        tmp_path / translation,
+        "---\nlang: pt-BR\nlanguage-version: translation\n"
+        "translation: example.ipynb\n---\n",
+    )
+    assert select_sources(
+        [source, translation], repository=tmp_path
+    ) == []
+
+
+def test_manual_dispatch_can_regenerate_a_paired_source(tmp_path: Path) -> None:
+    source = "posts/example.ipynb"
+    write_notebook(tmp_path / source, "---\nlang: en\n---\n")
+    assert select_sources(
+        [], repository=tmp_path, manual_source=source
+    ) == [source]

--- a/posts/2020-09-19-Distilling-BERT-pt-BR.ipynb
+++ b/posts/2020-09-19-Distilling-BERT-pt-BR.ipynb
@@ -1,0 +1,808 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "author: Andre Barbosa\n",
+    "categories:\n",
+    "- masters\n",
+    "- nlp\n",
+    "- knowledge-distill\n",
+    "date: '2020-09-19'\n",
+    "description: Um passo a passo sobre como ele funciona :)\n",
+    "lang: pt-BR\n",
+    "translation: 2020-09-19-Distilling-BERT.ipynb\n",
+    "language-version: translation\n",
+    "title: Destilando o Pré-Treinamento do BERT\n",
+    "toc: true\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Uma rápida revisão\n",
+    "\n",
+    "Eu lembro algum dia de 2016, quando eu estava no início da kinha carreira, eu encontrei por acaso o [blog do Chirs McCormick sobre Word2Vec](http://mccormickml.com/2016/04/19/word2vec-tutorial-the-skip-gram-model/). Honestamente, acredito que o [artigo escrito pelo Tomas Mikolov](https://papers.nips.cc/paper/5021-distributed-representations-of-words-and-phrases-and-their-compositionality.pdf) foi uma das indéias mais interessantes que eu já encontrei nessa minha jornada como cientista de dados {% fn 1 %} :) \n",
+    "\n",
+    "{{ 'Fun Fact: O [perfil do LinkedIn do Miklov](https://www.linkedin.com/in/tomas-mikolov-59831188/?originalSubdomain=cz) mostra que ele trabalhou na Microsoft, Google e Facebook; outro autor do W2V, [Ilya Sutskever](http://www.cs.toronto.edu/~ilya/) teve oportunidades de trabalhar com os maiores pesquisadores da área moderna de IA, tais como [Geoffrey Hinton](https://www.cs.toronto.edu/~hinton/) e [Andrew Ng](https://www.andrewng.org/). Além disso, ele é um dos fundadores da [Open AI](https://openai.com/)! ' | fndetail: 1 }}\n",
+    "\n",
+    "## O que são Word Embeddings\n",
+    "\n",
+    "\n",
+    "Segundo a documentação do [Pytorch](https://pytorch.org/docs/stable/generated/torch.nn.Embedding.html),  um **Embedding** pode ser definido da seguinte forma: \n",
+    "\n",
+    "   >Uma tabela de lookup formada por um _dicionário_ de tamanho fixo.\n",
+    "\n",
+    "Podemos interpretar os embeddings como uma forma de converter _índices_ em _vetores_ de um tamanho específico. Logo, **word embeddings**, podem ser entendidos como palavras que são convertidas para inteiros e **esses** números servem de índices para diferentes linhas de uma matriz que representa o espaço vetorial.'\n",
+    "\n",
+    "Eu escrevi um código usando [manim](https://github.com/3b1b/manim) que ilustra isso:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](images/media/videos/scene/720p30/EmbeddingExample.gif \"Nesse exemplo, a dimensão do embedding é NxM, em que N seria o tamanho do vocabulário (8) e M é 4.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Podemos interpretar cada dimensão como um único neurônio de uma camada oculta, e, então, **o tamanho desses embeddings podem ter seus números alterados** a partir de uma rede neural. Essa é, basicamente, a ideia por trás de algoritmos como [Word2Vec](https://patents.google.com/patent/US9037464B1/en) e [fastText](https://fasttext.cc/) {% fn 2 %} \n",
+    "\n",
+    "Já existem algumas bibliotecas que já fornecem alguns vetores pré-treinados. Por exemplo, considere o [código Spacy](https://spacy.io/models) abaixo:\n",
+    "\n",
+    "{{ 'Eu não irei cobrir Word2Vec nesse blog post. Se você não tem familiaridade com isso, [consulte aqui](http://jalammar.github.io/illustrated-word2vec/); [aqui](http://mccormickml.com/2016/04/19/word2vec-tutorial-the-skip-gram-model/) e [aqui](https://www.youtube.com/watch?v=ASn7ExxLZws). Infelizmente, todos os links estão em inglês. Se você achar quiser que eu escreva um post sobre Word2Vec em português, me envie uma mensagem no meu [linkedin](https://www.linkedin.com/in/barbosaandre/) :)' | fndetail: 2 }}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Considere a sentença 'O rato roeu a roupa do rei de Roma!'\n'O' representação vetorial com tamanho 96. Seus primeiros 5 elementos são: [ 1.2   0.18 -0.97 -5.64 -4.65]\n'rato' representação vetorial com tamanho 96. Seus primeiros 5 elementos são: [ 3.17  5.36  0.14 -1.27  3.09]\n'roeu' representação vetorial com tamanho 96. Seus primeiros 5 elementos são: [ 1.17 -2.8   2.39 -0.33  0.4 ]\n'a' representação vetorial com tamanho 96. Seus primeiros 5 elementos são: [-0.99  4.67  1.21 -3.48 -2.62]\n'roupa' representação vetorial com tamanho 96. Seus primeiros 5 elementos são: [ 3.6   3.54 -0.66 -1.9   1.99]\n'do' representação vetorial com tamanho 96. Seus primeiros 5 elementos são: [-3.28 -2.15 -1.62  4.33  0.55]\n'rei' representação vetorial com tamanho 96. Seus primeiros 5 elementos são: [ 2.43  2.99 -2.72  2.31  5.31]\n'de' representação vetorial com tamanho 96. Seus primeiros 5 elementos são: [-4.49 -1.73  2.27  7.9   3.35]\n'Roma' representação vetorial com tamanho 96. Seus primeiros 5 elementos são: [ 4.87  0.42  1.91 -1.68  6.37]\n'!' representação vetorial com tamanho 96. Seus primeiros 5 elementos são: [ 0.61 -3.03 -1.37 -0.38 -2.72]\n"
+     ]
+    }
+   ],
+   "source": [
+    "#collapse-hide\n",
+    "import spacy\n",
+    "nlp = spacy.load(\"pt_core_news_sm\")\n",
+    "\n",
+    "print(\"Considere a sentença 'O rato roeu a roupa do rei de Roma!'\")\n",
+    "text = nlp(\"O rato roeu a roupa do rei de Roma!\")\n",
+    "for word in text:\n",
+    "    print(\n",
+    "        f\"'{word.text}' representação vetorial com tamanho {word.vector.shape[0]}. Seus primeiros 5 elementos são: {word.vector[:5].round(2)}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Essas palavras são representações que foram treinadas com base nos dados do [Common Crawl usando o algoritmo GloVe](https://github.com/explosion/spacy-models/releases/tag/en_core_web_md-3.0.0). Diferente do exemplo usado no começo deste blog, a palavra '!' também teve uma representação vetorial. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Para formar frases, podemos combinar embeddings de palavras de formas diferentes. Segundo a [documentação do spacy](https://spacy.io/usage/vectors-similarity#_title):\n",
+    "\n",
+    "> Modelos que possuem vetores de palavras estão disponíveis pelo atributo Token.vector. Doc.vector e Span.vector, por padrão são representados pela **média** da representação de seus vetores. \n",
+    "\n",
+    "\n",
+    "Logo, a frase que estamos usando como exemplo tem a seguinte representação vetorial:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Os primeiros 5 valores de 'The quick brown fox jumps over the lazy dog!!': [-0.23  0.08 -0.03 -0.07 -0.02]\n"
+     ]
+    }
+   ],
+   "source": [
+    "#hide_input\n",
+    "print(f\"Os primeiros 5 valores de 'The quick brown fox jumps over the lazy dog!!': {text.vector[:5].round(2)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Limitações dos Word Embeddings\n",
+    "\n",
+    "Apesar de Word Embeddings trouxeram muitos benefícios na área de linguística computacional, eles possuem algumas limitações. Existe um fenômeno na linguística chamado _polissemia_. De acordo com o [wikipedia](https://pt.wikipedia.org/wiki/Sem%C3%A2ntica):\n",
+    "\n",
+    "> É a propriedade que uma mesma palavra tem de apresentar vários significados. Exemplos: Ele ocupa um alto posto na empresa. / Abasteci meu carro no posto da esquina. / Os convites eram de graça. / Os fiéis agradecem a graça recebida."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Considerando o exemplo acima, mesmo que as palavras tenham **significados diferentes** por conta do contexto, **sua representação vetorial é a mesma**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Primeiros cinco valores da palavra 'posto': [ 2.23  0.89  1.63  1.8  -0.12]\n"
+     ]
+    }
+   ],
+   "source": [
+    "#hide_input\n",
+    "print(f\"Primeiros cinco valores da palavra 'posto': {nlp('posto').vector[:5].round(2)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Se pegarmos duas frases: `Ele ocupa um alto posto na empresa` e `Abasteci meu carro no posto da esquina`, então nós teremos os seguintes vetores:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Os primeiros 5 valores do vetor da sentença 'Ele ocupa um alto posto na empresa ': [ 0.55  1.04  0.21 -0.36  0.51]\nOs primeiros 5 valores do vetor da sentença Abasteci meu carro no posto do alto do morro ': [ 0.73  0.82 -0.78  2.11  0.61]\n"
+     ]
+    }
+   ],
+   "source": [
+    "text1 = nlp(\"Ele ocupa um alto posto na empresa\")\n",
+    "text2 = nlp(\"Abasteci meu carro no posto do alto do morro\")\n",
+    "\n",
+    "print(f\"Os primeiros 5 valores do vetor da sentença '{text1} ': {text1.vector[:5].round(2)}\")\n",
+    "print(f\"Os primeiros 5 valores do vetor da sentença {text2} ': {text2.vector[:5].round(2)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ao calcular a **similaridade de cossenos** entre a média destes vetores:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Similaridade:\n 'Ele ocupa um alto posto na empresa' and 'Abasteci meu carro no posto do alto do morro': 0.5666443705558777\n"
+     ]
+    }
+   ],
+   "source": [
+    "# collapse-hide\n",
+    "from sklearn.metrics.pairwise import cosine_similarity\n",
+    "\n",
+    "print(\n",
+    "    f\"Similaridade:\\n '{text1}' and '{text2}': \"\n",
+    "    f\"{cosine_similarity(text1.vector.reshape(1, -1),text2.vector.reshape(1, -1))[0][0]}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Isso indica que ambos os vetores tem alguma similares. Contudo, a razão disso foi o uso de palavras parecidas, uma vez que o significado das sentenças é **completamente** diferente. \n",
+    "\n",
+    "Isso é algo que o BERT tenta resolver.{% fn 3 %} \n",
+    "\n",
+    "\n",
+    "\n",
+    "{{ 'Existem alguns percursores do BERT como o [ELMo](https://allennlp.org/elmo); [ULMFit](https://arxiv.org/abs/1801.06146) e [Open AI Transformer](https://openai.com/blog/language-unsupervised/) que eu não irei cobrir aqui. Por favor, caso você queira, confira esse post [aqui](http://jalammar.github.io/illustrated-bert/) para saber mais' | fndetail: 3 }}\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# BERT"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Attention é tudo o que você precisa\n",
+    "\n",
+    "O artigo [Attention is all you need](https://arxiv.org/abs/1706.03762) introduziu a chamada arquitetura Transformer, que pode ser resumida pela imagem abaixo:\n",
+    "\n",
+    "![](images/transformer.png \"A arquitetura Transformer. Fonte: https://arxiv.org/abs/1706.03762\")\n",
+    "\n",
+    "A principal motivação por trás desse paper é que arquiteturas baseadas em _RNN_ tem um custo computacional de memória caro. A proposta por trás dos Transformers, então, é que resultados similareas à uma _RNN_ poderiam ser obtidos de uma forma muito mais eficiente aplicas, **apenas**, mecanismos de atenção (e evitando arquiteturas até então conhecidas, como _CNN_ ou _RNN_) !{% fn 4 %} Apesar do fato de que a proposta original em torno dos Transformers é que eles resolveriam problemas de tradução, percebeu-se que apenas algumas variações em seu funcionamento seriam capazes de atingir resultados **incríveis** em outras áreas. Essa é, basicamente, a principal motivação por trás do modelo **BERT**!\n",
+    "\n",
+    "\n",
+    "{{ '[O grupo de NLP de Harvard](http://nlp.seas.harvard.edu/2018/04/03/attention.html) escreveu um blog post muito bom que explica o passo a passo desse paper, além de apresentar uma implementação do mesmo em pytorch. Se você tiver interesse de entender essa arquiteutra com mais detalhes, eu recomendo dar uma lida! ' | fndetail: 4 }}\n",
+    "\n",
+    "### Atenção?\n",
+    "\n",
+    "Segundo a aula de [Transformer e Atenção do curso de Fundamentos de Deep Learning da NYU](https://atcold.github.io/pytorch-Deep-Learning/en/week12/12-3/):\n",
+    "\n",
+    "   > Transformers são compostos por módulos de atenção, os quais podem ser entendidos como um mapeamento entre conjuntos (não sequências). Em outras palavras, nós não precisamos nos preocupar entre a relação de **ordenação** entre os valores de entrada e saída.\n",
+    "   \n",
+    "\n",
+    "Ao analisarmos os mecanismos de atenção da arquitetura transformer, tanto o _Multi-Head Attention_ quanto _Multi-Head Masked Attention_ possuem 3 _Arrow Heads_. Cada uma dessas cabeças tem a seguinte representação:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "   - _Q_ Significa o vetor da **query** , com uma dimensão $d_k$ \n",
+    "   - _K_ Significa o vetor da **chave** (key), o qual também tem $d_k$\n",
+    "   - _V_ Significa o vetor de **value**, com uma dimensão $d_v$\n",
+    "   \n",
+    "   O par **KV**, no caso, são os inputs da rede, enquanto o *Q* é a saída de uma camada específica.\n",
+    "\n",
+    "### Armazenamento Key-Value\n",
+    "\n",
+    "Ainda de acordo com uma das aulas do curso[ Fundamentos de Deep Learning da NYU](https://atcold.github.io/pytorch-Deep-Learning/en/week12/12-3/):\n",
+    "\n",
+    "> O armazenamento chave-valor (_key-value_) é um paradigma desenvolvido para armazenar (saving), recuperar (querying), e gerenciar arrays associativos (dictionaries/hash tables)\n",
+    "\n",
+    ">Por exemplo, considere que queremos fazer uma receita de _lasanha_. Nós temos a receita em um livro e , para encontrala, procuramos pela palavra _lasanha_, que seria a nossa **query**. Essa query é comparada contra todas as outras **chaves** possíveis. Estas, por sua vez, poderiam representar os títulos de todas as receitas no livro. Então, podemos checar aplicar um matching score entre todas as **chaves** em relação à **query**. Caso a saída desse score seja o argmax, podemos retornar apenas a receita (**value**) com o valor máximo. Se for a softmax, podemos retornar uma distribuição de probabilidades e, então, descobrir as receitas mais similares com a query ou as menos similares.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Warning: Eu decidi não cobrir os conceitos de atenção em grandes detalhes. Para quem quiser saber mais, eu fortemente recomendo o curso da NYU de Fundamentos de Deep Learning que eu já citei acima.\n",
+    "\n",
+    "> Note: De uma maneira genérica, um mecanismo de atenção pode ser entendido, basicamente, como uma medida de correção entre dois conjuntos de palavras. Para quem quer, realmente, estudar o assunto em profundidade, esse [blog](https://lilianweng.github.io/lil-log/2018/06/24/attention-attention.html) é excelente."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Encoding Posicional\n",
+    "\n",
+    "[Eu retirei essa sessão por parte do blog annotated transformer](http://nlp.seas.harvard.edu/2018/04/03/attention.html#prelims), onde é possível encontrar uma implementação em pytorch. Na verdade, o quote abaixo é retirado diretamente do paper [Attention is all you need](https://arxiv.org/pdf/1706.03762.pdf):\n",
+    "\n",
+    ">Uma vez que nosso modelo não contém recorrência ou convolução, para fazer com que o modelo aprenda alguma noção de sequência, nós precisamos injetar alguma informação sobre a posição absoluta ou relativa sobre as palavras (tokens) de uma certa sequência. Esses \"encoding posicionais\" são somados aos embeddings de entrada tanto na pilha de encoder, quanto na pilha de decoder. Por conta disso, o \"encoding posicional\" tem a mesma dimensão $d_{model}$ que os embeddings (para que, então, eles possam ser somados).\n",
+    "\n",
+    "\n",
+    "![](images/positional_encoding.png \"Um exemplo de um embedding posicional que gera ondas senóides com base no tamanho. Note que cada dimensão gera uma senóide com uma frequência diferente. Fonte: http://nlp.seas.harvard.edu/2018/04/03/attention.html\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## O modelo BERT\n",
+    "\n",
+    "O modelo BERT é, na prática, um modelo _encoder_, derivado da arquitetura transformer. Considerando os modelos treinados do [paper](https://arxiv.org/pdf/1810.04805.pdf), o modelo **base** consiste de 12 camadas _encoder_ empilhados, enquanto o modelo **large** é composto de 24 camadas _encoder_ empilhadas."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "De acordo com o paper [Attention is all you need paper](https://arxiv.org/pdf/1706.03762.pdf):\n",
+    "\n",
+    "> O encoder é composto por uma pilha de $N = 6$ camadas. Cada camada é formada por **dois \n",
+    "sub-camada**. A primeira sub-camada é um mecanismo **multi-head self-attention**, enquanto a segunda é uma rede **fully connected feed-forward position wise **. Nós aplicamos uma [residual connection](https://arxiv.org/abs/1512.03385) ao redor de cada uma das duas sub-camadas, seguido de uma [camada de normalização](https://arxiv.org/abs/1607.06450)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](images/sublayers.jpg \"The encoder layer. Source: https://atcold.github.io/pytorch-Deep-Learning/en/week12/12-1/\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The Multi-Head Attention\n",
+    "\n",
+    "Basicamente, o mecanismo de atençção multi head é um _tipo_ de mecanismo de atenção. Ele formado pela _concatenação_ de outro mecanosmo, o _produto interno_ (scaled dot). A representação de ambos mecanismos se dá pela imagem abaixo:\n",
+    "\n",
+    "\n",
+    "![](images/attention_specific.png \"(escerda) Atenção Scaled Dot-Product seguida da atenção Multi-Head, que consistem em uma sére de camadas de atenção rodando em paralelo. Fonte: https://atcold.github.io/pytorch-Deep-Learning/en/week12/12-1/\")\n",
+    "\n",
+    "> Note: A forma de calcular a atenção Scaled Dot-Product é dada por $softmax(\\frac{QK^T}{\\sqrt{n}})V$, em que *K*, *V* and *Q* são os mesmos que os descritos na sessão antetior, enquanto *n* representa o número de elementos dentro do conjunto. \n",
+    "\n",
+    "\n",
+    "_h_, ou o número de camadas de atenção é igual a $12$ no caso do $\\text{BERT}_\\text{base}$, e $16$ no caso do $\\text{BERT}_\\text{large}$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Conexões Residuais\n",
+    "\n",
+    "Cada subcamada da pilha de encoder contém uma conexão resiudal (a flecha curvada à esquerda) adicionada à saída da subcamada anterior à camada de normalização. A [idea de Conexões Residuais](https://arxiv.org/pdf/1512.03385.pdf) vem do campo de visão computacional e, na verdade, é uma técnica que pode ser resumida pela seguinte imagem:\n",
+    "\n",
+    "![](images/residual_connection.png \"Residual Connection example. Source (https://arxiv.org/pdf/1512.03385.pdf)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Considerando a arquitetura de pilha Encoder, cada $\\mathcal{F}(x)$ significa ou a atenção _Multi-Head_ ou a camada _Feed Forward_. Logo, citando o paper:\n",
+    "\n",
+    "> Ou seja, a **saída de cada sub camada é LayerNorm(x + Sublayer(x))**, onde cada Sublayer(x) é a função implementada pela subcamada em si. Para _facilitar essas conexões individuais_, todas as sub-camadas do modelo, assim como as camadas de embedding, produzem saídas de dimenção $d_{model} = 512$ {% fn 5 %}.\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "{{ 'No caso do [BERT](https://arxiv.org/pdf/1810.04805.pdf), tenha em mente que $N$ pode ser $12$ \\(BERT<sub>base</sub>\\) ou $24$ (\\(BERT<sub>large</sub>\\) e _d<sub>model</sub>_ é 768 para o BERT base e 1024 para o BERT large' | fndetail: 5 }}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Mas o que, de fato, está sendo encodado?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Representação dos Embeddings\n",
+    "\n",
+    "Quando o paper foi escrito, os autores tinham em mente que o BERT deveria performar bem em diferentes tarefas, tais como binary e multi lablel classification_; _language modeling_; _question and answering_; _named entity recognition_; _etc_. Fazendo a paráfrase do original:\n",
+    "\n",
+    "> Nossa representação de entrada tem que, de maneira desambiguável, representar tanto uma sentença única, quanto um par de sentenças em uma única sequência de tokens. Diferente de uma sentença na linguística tradicional, no BERT, uma \"sentença\" pode ser um span arbitrário de texto contínuo. Uma \"sequência\" representa a sequência de tokens de entrada no BERT, o que pode ser uma sentença única ou duas sentenças agrupadas.\n",
+    "\n",
+    "\n",
+    "Para performar e criar esses embeddings de sentenças, utilizou-se o [WordPiece](https://arxiv.org/abs/1609.08144). Então, além de adicionar o [CLS] token, pares de sentença (e.g. sentence _A_ and _B_) são concatenados em uma sentença única, sendo separados por um token especial [SEP] (e.g. _A_ [SEP] _B_). \n",
+    "\n",
+    "Então:\n",
+    "\n",
+    "> Para um dado token, sua representação é construída ao somar o token respectivo, o segmento (A ou B) e os positional embeddings."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](images/token_embeddings.png \"BERT input representation. Source: https://arxiv.org/pdf/1810.04805.pdf\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Pré Treinamento do BERT\n",
+    "\n",
+    "A primeira parte do BERT é um processo de pé treinamento que tem **duas** funções objetivo\n",
+    "\n",
+    "## Modelo de Linguagem Mascarado (MLM)\n",
+    "\n",
+    "Conforme estamos alimentando o modelo com sentenças e considerando que estamos treinando um modelo de linguagem (isto é, queremos prever a palavra seguinte dado as palavras anteriores), como o BERT é bidirecional, isso acaba sendo problemático. A solução, proposta por essa _loss function_ é relativamente simples. Para fraseando o [paper](https://arxiv.org/pdf/1810.04805.pdf):\n",
+    "\n",
+    "> Infelizmente, modelos de linguagem convencionais são apenas treinados considerando como input sentenças da esquerda para direita ou direita para esquerda, já que condicionalidade bidirecional permitiria que cada palavra \"tivesse acesso a ela mesma\" e, logo, o modelo conseguiria fazer a previsão de uma maneira direta.\n",
+    "\n",
+    "> Para treinar uma representação bidirecional, nós mascaramos, de forma aleatória, uma certa porcentagem da entrada e prevismos estes tokens que forem ocultados. Nos referimos a esse processo como modelo de linguagem mascarado, apesar de que ele também recebe o nome de _cloze task_ na [literatura](https://journals.sagepub.com/doi/abs/10.1177/107769905303000401). \n",
+    "\n",
+    "No caso do BERT, 15% de cada sentença é mascarada durante a etapa de treinamento."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](images/mlm.png \"MLM task. Taken from here: http://jalammar.github.io/illustrated-bert/\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Predição da Próxima Sentença (Next Sentence Prediction- NSP)\n",
+    "\n",
+    "Para aprender relações entre pares de sentença (i.e. tarefas de perguntas e respostas), os autores precisaram pensar em algo além da modelagem de língua tradicional. Então:\n",
+    "\n",
+    ">  Para treinar um modelo que entenda relacionamento de sentenças, nós pre treinamos um modelo binarizado previsor de próxima sentença que poderia ser gerado de qualquer corpus monolingual. Especificamente, quando escolhemos sentenças A e B para cada exemplo de pré treino, 50% das vezes B é, de fato, a sentença seguinte de A (marcada como `IsNext`) e 50% das vezes é uma sequência aleatória (marcada como `NotNext`). \n",
+    "\n",
+    "Ambas funções objetivo (MLM e NSP) são usadas para o pré treinamento do BERT  :)\n",
+    "\n",
+    "![](images/nsp.png \"Next Sentence Preiction. Fonte: http://jalammar.github.io/illustrated-bert/\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Note: A _loss_ de treinamento é a soma das médias da MLM e NSP"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Important: Você deve ter notado que, durante o treinamento, não é necessário o uso de _labels_, já que derivamos _labels_ a partir do input. Logo, o modelo de Pré Treinamento do BERT é considerado _self-surpervised_!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Resumão de tudo\n",
+    "\n",
+    "Como estamos lidando com embeddings de **sentenças** (não **palavras**), precisamos de uma forma de fazer o encoding desse input da maneira certa. Vamos ver como o BERT faz:\n",
+    "\n",
+    "   - Primeiro recebemos os tokens de texto como entrada\n",
+    "   - Aplicamos o WordPiece Tokenizer\n",
+    "   - Essa entrada entra na pilha de Encoder\n",
+    "   - Treinamos a rede (Pre-Training step)\n",
+    "   - Para os familiarizados com redes convolucionais, podemos dizer que o embedding do token [CLS] funciona como uma representação \"pooled\" ([ref](https://arxiv.org/pdf/2002.08909.pdf)) da sentença e, logo, pode ser usada como um embedding **contextual**. No caso, ela serve de entrada para uma rede neural para resolver problemas de classificação!\n",
+    "   - Dependendo da tarefa de _Fine tuning_, é possível usar os embeddings de um token diferente do CLS\n",
+    "   \n",
+    " > Important: Se desconsiderarmos a tarefa de fine tuning, o vetor CLS não tem uma representação muito grande, uma vez que ele foi treinado por meio da _loss_ NSP ([ref](https://arxiv.org/pdf/1810.04805.pdf))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Eu tentei resumir o processo todo com o gif abaixo\n",
+    "\n",
+    "![](images/media/videos/scene/720p30/TransformerEncoderExample.gif \"Entire Forward passing in BERT\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Na prática\n",
+    "\n",
+    "Para mostrar o embedding de sentenças do BERT funcionando, eu irei usar a biblioteca [Hugging Face's transformer](https://huggingface.co/transformers/). Aqui, uma vez que o **Bert Model para Modelos de Linguagem** já foi treinado, Eu usarei o BERT sem nenhuma cabeça (i.g., `LanguageModeling head` or `SentenceClassification head`) na ponta!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "Downloading: 100%|██████████| 872k/872k [00:01<00:00, 699kB/s]\n",
+      "Downloading: 100%|██████████| 625/625 [00:00<00:00, 153kB/s]\n",
+      "Downloading: 100%|██████████| 672M/672M [03:07<00:00, 3.58MB/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "#collapse\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "from transformers import BertModel,BertTokenizer, BertForPreTraining\n",
+    "tokenizer = BertTokenizer.from_pretrained(\"bert-base-multilingual-uncased\")\n",
+    "model = BertModel.from_pretrained(\"bert-base-multilingual-uncased\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sequence_0 = \"Ele ocupa um alto posto na empresa\"\n",
+    "sequence_1 = \"Abasteci meu carro no posto do alto do morro\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Mapeamento de sequencia 0 word2Id: [101, 12002, 28905, 10316, 13248, 14645, 10135, 14443, 102]\nMapeamento de sequence 1 word2Id: [101, 51448, 11176, 10532, 44780, 43562, 10181, 14645, 10154, 13248, 10154, 43522, 102]\n"
+     ]
+    }
+   ],
+   "source": [
+    "#collapse-hide\n",
+    "sequence_0_w2id = tokenizer.encode(sequence_0) # we need to map words to id's :)\n",
+    "sequence_1_w2id = tokenizer.encode(sequence_1)\n",
+    "\n",
+    "print(f\"Mapeamento de sequencia 0 word2Id: {sequence_0_w2id}\")\n",
+    "print(f\"Mapeamento de sequence 1 word2Id: {sequence_1_w2id}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "tensor([[  101, 12002, 28905, 10316, 13248, 14645, 10135, 14443,   102]])"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 7
+    }
+   ],
+   "source": [
+    "sequence_0_embeddings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#collapse-hide\n",
+    "sequence_0_embeddings = torch.tensor(sequence_0_w2id).unsqueeze(0)  # Batch size 1\n",
+    "sequence_0_embeddings = model(sequence_0_embeddings)[0].detach().numpy()\n",
+    "sequence_1_embeddings = torch.tensor(sequence_1_w2id).unsqueeze(0)  # Batch size 1\n",
+    "sequence_1_embeddings = model(sequence_1_embeddings)[0].detach().numpy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "((1, 9, 768), (1, 13, 768))"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 10
+    }
+   ],
+   "source": [
+    "sequence_0_embeddings.shape, sequence_1_embeddings.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Podemos remover a primeira sentença, já que ela representa o tamanho do batch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "((9, 768), (13, 768))"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 11
+    }
+   ],
+   "source": [
+    "#collapse-hide\n",
+    "sequence_0_embeddings=sequence_0_embeddings[0]\n",
+    "sequence_1_embeddings=sequence_1_embeddings[0]\n",
+    "sequence_0_embeddings.shape, sequence_1_embeddings.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Podemos ver que esse modelo gera um embedding para cada palavra das frases mais dois: um para o token `CLS` e outro para o token `SEP`\n",
+    "\n",
+    "\n",
+    "Agora, vamos calcular a similaridade entre o token CLS e a média dos tokens que compõe a frase:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Similaridade de Cosseno entre o token CLS e a média dos tokens de\n'Ele ocupa um alto posto na empresa' tokens: -0.04759013652801514\n"
+     ]
+    }
+   ],
+   "source": [
+    "# collapse-hide\n",
+    "CLS_TOKEN_0 = sequence_0_embeddings[0]\n",
+    "CLS_TOKEN_WORDS_0 = np.mean(sequence_0_embeddings[[1, 2, 3, 4]], axis=0)\n",
+    "print(\n",
+    "    f\"Similaridade de Cosseno entre o token CLS e a média dos tokens de\\n'{sequence_0}'\"\n",
+    "    f\" tokens: {cosine_similarity(CLS_TOKEN_0.reshape(1, -1), CLS_TOKEN_WORDS_0.reshape(1, -1))[0][0]}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Similaridade de Cosseno entre o token CLS e a média dos tokens de\n'Abasteci meu carro no posto do alto do morro' tokens: 0.05738348513841629\n"
+     ]
+    }
+   ],
+   "source": [
+    "# collapse-hide\n",
+    "CLS_TOKEN_1 = sequence_1_embeddings[0]\n",
+    "CLS_TOKEN_WORDS_1 = np.mean(sequence_1_embeddings[[1, 2, 3, 4]], axis=0)\n",
+    "print(\n",
+    "    f\"Similaridade de Cosseno entre o token CLS e a média dos tokens de\\n'{sequence_1}'\"\n",
+    "    f\" tokens: {cosine_similarity(CLS_TOKEN_1.reshape(1, -1), CLS_TOKEN_WORDS_1.reshape(1, -1))[0][0]}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Como dito pelo paper, o token CLS não tem significado nenhum aqui, Vamos, então, analisar a similaridade entre as médias dos tokens de ambas as sentenças"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Similaridade de Cosseno entre o token CLS e a média dos tokens de\n'Ele ocupa um alto posto na empresa'and 'Abasteci meu carro no posto do alto do morro' tokens :0.5034023523330688\n"
+     ]
+    }
+   ],
+   "source": [
+    "# hide-input\n",
+    "print(\n",
+    "     f\"Similaridade de Cosseno entre o token CLS e a média dos tokens de\\n'{sequence_0}'and '{sequence_1}'\"\n",
+    "    f\" tokens :{cosine_similarity(CLS_TOKEN_WORDS_0.reshape(1, -1), CLS_TOKEN_WORDS_1.reshape(1, -1))[0][0]}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Como esperado**, apesar de palavras parecidas terem sido usadas, ccomo o contexto entre palavras foram totalmente disferentes, a similaridade de embeddings aqui foi menor do que o de combinação de palavras, usado no começo do artigo."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Conclusion\n",
+    "\n",
+    "Parabéns! Você aprendeu os principais conceitos por trás do modelo BERT :) Se você tiver interesse em ver outros posts em português, por favor me envie uma mensagem!\n",
+    "\n",
+    "Além disso, se você quer ter mais detalhes de como usar o BERT de uma maneira prática, eu recomendo esse [blog post](https://huggingface.co/blog/how-to-train)!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Recursos que me inspiraram\n",
+    "\n",
+    "Além dos papers que eu usei para citar nesse post, eu também gostaria de enfatizar que os links abaixo serviram de uma inspiração absurda!\n",
+    "\n",
+    "- http://jalammar.github.io/illustrated-bert/\n",
+    "- https://jalammar.github.io/illustrated-transformer/\n",
+    "- http://nlp.seas.harvard.edu/2018/04/03/attention.html"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Reconhecimento\n",
+    "\n",
+    "Eu gostaria de agradecer, de verdade, alguns colegas que fizeram a revisão técnica desse blog :)\n",
+    "\n",
+    "\n",
+    "Em ordem alfabética:\n",
+    "\n",
+    "- [Alan Barzilay](https://www.linkedin.com/in/alan-barzilay-58754855/)\n",
+    "- [Alvaro Marques](https://www.linkedin.com/in/alvaro-marques-9a10aa131/)\n",
+    "- [Igor Hoelscher](https://www.linkedin.com/in/ighoelscher/)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3.7.2 64-bit ('citadel')",
+   "metadata": {
+    "interpreter": {
+     "hash": "0635a80df3c0ba425046ad05be36aa3494c9972f2ddd763659334119e4736704"
+    }
+   }
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2-final"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": true
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/posts/2020-09-19-Distilling-BERT.ipynb
+++ b/posts/2020-09-19-Distilling-BERT.ipynb
@@ -16,6 +16,8 @@
     "- knowledge-distill\n",
     "date: '2020-09-19'\n",
     "description: Step by step about its inner work from scratch :)\n",
+    "lang: en\n",
+    "translation: 2020-09-19-Distilling-BERT-pt-BR.ipynb\n",
     "hide: false\n",
     "hide_binder_badge: false\n",
     "hide_colab_badge: false\n",

--- a/posts/2026-07-23-Scaling-MyPost-WithAIAgents.ipynb
+++ b/posts/2026-07-23-Scaling-MyPost-WithAIAgents.ipynb
@@ -74,7 +74,7 @@
     "\n",
     "At a high level, the pipeline will look like this:\n",
     "\n",
-    "![](images\\scaling-translation-posts\\architeture-automate-translation-v2.png)\n",
+    "![](images/scaling-translation-posts/architeture-automate-translation-v2.png)\n",
     "\n",
     "*This diagram was created with the help of ChatGPT Sol using high reasoning effort.*\n",
     "\n",
@@ -286,7 +286,7 @@
     "\n",
     "Before evaluating model outputs, I needed to validate the bilingual dataset itself. I asked Codex to create a review interface following guidance from the [*Evals for AI Engineers* book](https://www.oreilly.com/library/view/evals-for-ai/9798341660717/). A screenshot of the interface appears below:\n",
     "\n",
-    "![](images\\scaling-translation-posts\\ui-review-translate.jpg)\n",
+    "![](images/scaling-translation-posts/ui-review-translate.jpg)\n",
     "\n",
     "\n",
     "The idea is simple: given the candidate pairs proposed by LaBSE and dynamic programming, do I agree with each alignment?\n"


### PR DESCRIPTION
Adds the post-merge Tower+ workflow that generates and validates a PT-BR notebook, uploads a rendered review artifact, and opens a separate draft translation PR.

Also fixes the broken architecture image path and restores the existing 2020 Distilling BERT Portuguese counterpart with reciprocal PT-BR/EN navigation.

Validation: 46 tests passed; the 2020 EN/PT-BR notebooks and 2026 translation post rendered successfully.