### PR TITLE
Handle Tower+ Markdown wrapper hallucinations

### DIFF
--- a/experiments/scaling-my-posts/src/translate_notebook.py
+++ b/experiments/scaling-my-posts/src/translate_notebook.py
@@ -29,6 +29,7 @@ PROTECTED = re.compile(
     r"|https?://[^\s)>]+"
 )
 CALLOUT_TITLE = re.compile(r'(title=")([^"]+)(")')
+FENCE_LINE = re.compile(r"^\s*(`{3,}|~{3,})(?:markdown|md)?\s*$", re.IGNORECASE)
 
 
 def split_markdown(text: str) -> list[str]:
@@ -153,6 +154,29 @@ def materialize_translation(text: str, protected: dict[str, str]) -> str:
     if not protected or PLACEHOLDER_PREFIX not in text:
         return text
     return restore(text, protected)
+
+
+def remove_model_code_fence_wrapper(source: str, translation: str) -> str:
+    """Remove only an outer Markdown fence invented by the translation model."""
+    if re.search(r"^(`{3,}|~{3,})", source, flags=re.MULTILINE):
+        return translation
+    lines = translation.splitlines()
+    nonempty = [index for index, line in enumerate(lines) if line.strip()]
+    if nonempty:
+        first = nonempty[0]
+        opening = FENCE_LINE.fullmatch(lines[first])
+        if opening:
+            del lines[first]
+            nonempty = [index for index, line in enumerate(lines) if line.strip()]
+            if nonempty:
+                last = nonempty[-1]
+                closing = FENCE_LINE.fullmatch(lines[last])
+                if closing and closing.group(1)[0] == opening.group(1)[0]:
+                    del lines[last]
+    result = "\n".join(lines).strip()
+    if re.search(r"^(`{3,}|~{3,})", result, flags=re.MULTILINE):
+        raise ValueError("Tower+ invented a code fence inside translated prose")
+    return result
 
 
 def translation_cache_key(text: str, protected: dict[str, str]) -> str:
@@ -328,7 +352,8 @@ class TowerMarkdownTranslator:
             instruction = (
                 "Translate the following technical blog Markdown from English to "
                 "Brazilian Portuguese. Preserve every Markdown marker, line break, "
-                "table column, and Quarto directive exactly. "
+                "table column, and Quarto directive exactly. Do not wrap the "
+                "translation in a Markdown code fence. "
             )
             if preserve_placeholders:
                 instruction += (
@@ -465,9 +490,13 @@ def translate_notebook(
         tasks, translations, strict=True
     ):
         assert translation is not None
-        cell_parts[cell_index][part_index] = materialize_translation(
-            translation,
-            protected,
+        source_part = cell_parts[cell_index][part_index]
+        cell_parts[cell_index][part_index] = remove_model_code_fence_wrapper(
+            source_part,
+            materialize_translation(
+                translation,
+                protected,
+            ),
         )
 
     for cell_index, parts in cell_parts.items():

--- a/experiments/scaling-my-posts/tests/features/translate_notebook.feature
+++ b/experiments/scaling-my-posts/tests/features/translate_notebook.feature
@@ -29,6 +29,20 @@ Feature: Generate a Portuguese notebook that is safe for an author to review
     And the original link "[English](https://example.com)" is retained
     And no new Markdown heading is introduced
 
+  Scenario: An outer code-fence wrapper added by Tower+ is removed safely
+    Given an English prose block contains no Markdown code fence
+    And Tower+ returns the translated prose inside an outer Markdown code fence
+    When the generator normalizes the translated block against its source
+    Then the Portuguese prose remains in the result
+    And the model-added outer code fence is removed
+
+  Scenario: A code fence invented inside translated prose blocks generation
+    Given an English prose block contains no Markdown code fence
+    And Tower+ inserts an invented code example inside the translated prose
+    When the generator validates the translated block against its source
+    Then the structurally unsafe translation is rejected
+    And the invented code cannot reach the generated notebook
+
   Scenario: A generated Portuguese notebook remains paired and unpublished
     Given source metadata describes a published English notebook
     When Portuguese metadata is generated for the source file "post.ipynb"

--- a/experiments/scaling-my-posts/tests/test_translate_notebook.py
+++ b/experiments/scaling-my-posts/tests/test_translate_notebook.py
@@ -16,6 +16,7 @@ from translate_notebook import (  # noqa: E402
     is_structural_block,
     materialize_translation,
     protect,
+    remove_model_code_fence_wrapper,
     source_frontmatter,
     split_markdown,
     translate_around_protected,
@@ -40,6 +41,30 @@ def test_materialize_accepts_an_already_reconstructed_fallback() -> None:
     protected = {"ZXQPROTECTED0000QXZ": "[the article](https://example.com)"}
     translated = "Leia [o artigo](https://example.com)."
     assert materialize_translation(translated, protected) == translated
+
+
+def test_model_added_markdown_wrapper_is_removed() -> None:
+    source = "## A heading\n\nA paragraph."
+    translated = "```markdown\n## Um título\n\nUm parágrafo.\n```"
+    assert remove_model_code_fence_wrapper(source, translated) == (
+        "## Um título\n\nUm parágrafo."
+    )
+
+
+def test_unclosed_model_added_markdown_wrapper_is_removed() -> None:
+    source = "## A heading\n\nA paragraph."
+    translated = "```markdown\n## Um título\n\nUm parágrafo."
+    assert remove_model_code_fence_wrapper(source, translated) == (
+        "## Um título\n\nUm parágrafo."
+    )
+
+
+def test_model_added_inner_fence_is_rejected() -> None:
+    with pytest.raises(ValueError, match="invented a code fence"):
+        remove_model_code_fence_wrapper(
+            "A paragraph.",
+            "Um parágrafo.\n```python\nprint('invented')\n```",
+        )
 
 
 def test_source_frontmatter_adds_an_idempotent_reciprocal_pair() -> None:

--- a/experiments/scaling-my-posts/tests/test_translate_notebook_bdd.py
+++ b/experiments/scaling-my-posts/tests/test_translate_notebook_bdd.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(SRC))
 from translate_notebook import (  # noqa: E402
     portuguese_frontmatter,
     protect,
+    remove_model_code_fence_wrapper,
     restore,
     translate_around_protected,
 )
@@ -203,6 +204,70 @@ def original_link_is_retained(
 @then("no new Markdown heading is introduced")
 def no_heading_is_introduced(context: dict[str, Any]) -> None:
     assert "\n#" not in context["result"]
+
+
+@given("an English prose block contains no Markdown code fence")
+def prose_without_code_fence(context: dict[str, Any]) -> None:
+    context["source"] = "This workflow translates a notebook after merge."
+
+
+@given("Tower+ returns the translated prose inside an outer Markdown code fence")
+def translated_prose_with_outer_wrapper(context: dict[str, Any]) -> None:
+    context["translation"] = (
+        "```markdown\n"
+        "Este fluxo traduz um notebook após o merge.\n"
+        "```"
+    )
+
+
+@when("the generator normalizes the translated block against its source")
+def normalize_translated_block(context: dict[str, Any]) -> None:
+    context["result"] = remove_model_code_fence_wrapper(
+        context["source"],
+        context["translation"],
+    )
+
+
+@then("the Portuguese prose remains in the result")
+def portuguese_prose_remains(context: dict[str, Any]) -> None:
+    assert context["result"] == "Este fluxo traduz um notebook após o merge."
+
+
+@then("the model-added outer code fence is removed")
+def outer_code_fence_is_removed(context: dict[str, Any]) -> None:
+    assert "```" not in context["result"]
+
+
+@given("Tower+ inserts an invented code example inside the translated prose")
+def translation_with_invented_inner_fence(context: dict[str, Any]) -> None:
+    context["translation"] = (
+        "Este fluxo traduz um notebook.\n"
+        "```python\n"
+        "print('invented')\n"
+        "```"
+    )
+
+
+@when("the generator validates the translated block against its source")
+def validate_translated_block(context: dict[str, Any]) -> None:
+    try:
+        remove_model_code_fence_wrapper(
+            context["source"],
+            context["translation"],
+        )
+    except ValueError as error:
+        context["error"] = error
+        context["result"] = None
+
+
+@then("the structurally unsafe translation is rejected")
+def unsafe_translation_is_rejected(context: dict[str, Any]) -> None:
+    assert "invented a code fence" in str(context["error"])
+
+
+@then("the invented code cannot reach the generated notebook")
+def invented_code_is_not_emitted(context: dict[str, Any]) -> None:
+    assert context["result"] is None
 
 
 @given("source metadata describes a published English notebook")


### PR DESCRIPTION
Prevents translation models from changing the Markdown code-fence structure of prose blocks.

For every translated block, the generator now enforces a general structural invariant:

- If the source contains no code fence, a model-added outer Markdown wrapper is removed.
- Both complete and truncated outer wrappers are handled.
- Any remaining model-invented inner fence is rejected rather than silently accepted.
- Source blocks that legitimately contain fences are left unchanged by this normalization.

The prompt also explicitly tells Tower+ not to wrap translated output in a code fence.

Validation: 49 experiment tests passed, including complete-wrapper, truncated-wrapper, and invented-inner-fence regression cases.